### PR TITLE
Fix: Conditions actually need to be fixed

### DIFF
--- a/Symfony/CS/Tests/Fixer/Symfony/YodaConditionsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/YodaConditionsFixerTest.php
@@ -32,19 +32,37 @@ class YodaConditionsFixerTest extends AbstractFixerTestBase
         return array(
             // valid conditions that should not be changed
             array('<?php return array(2) == $a;'),
-            array('<?php return $a == array(2);'),
             array('<?php return array($a) == $a;'),
-            array('<?php return $a == array($a);'),
             array('<?php return $this->getStuff() === $myVarirable;'),
-            array('<?php return $myVarirable === $this->getStuff();'),
             array('<?php return 2 * $myVar % 3 === $a;'),
-            array('<?php return $a === 2 * $myVar % 3;'),
             array('<?php return ($a & self::MY_BITMASK) === $a;'),
-            array('<?php return $a === ($a & self::MY_BITMASK);'),
             array('<?php return count($this->array[$var]) === $a;'),
-            array('<?php return $a === count($this->array[$var]);'),
 
             // simple non-Yoda conditions that need to be fixed
+            array(
+                '<?php return array(2) == $a;',
+                '<?php return $a == array(2);',
+            ),
+            array(
+                '<?php return array($a) == $a;',
+                '<?php return $a == array($a);',
+            ),
+            array(
+                '<?php return $this->getStuff() === $myVarirable;',
+                '<?php return $myVarirable === $this->getStuff();',
+            ),
+            array(
+                '<?php return 2 * $myVar % 3 === $a;',
+                '<?php return $a === 2 * $myVar % 3;',
+            ),
+            array(
+                '<?php return ($a & self::MY_BITMASK) === $a;',
+                '<?php return $a === ($a & self::MY_BITMASK);',
+            ),
+            array(
+                '<?php return count($this->array[$var]) === $a;',
+                '<?php return $a === count($this->array[$var]);',
+            ),
             array(
                 '<?php return 2 == $a;',
                 '<?php return $a == 2;',

--- a/Symfony/CS/Tests/Fixer/Symfony/YodaConditionsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/YodaConditionsFixerTest.php
@@ -33,7 +33,7 @@ class YodaConditionsFixerTest extends AbstractFixerTestBase
             // valid conditions that should not be changed
             array('<?php return array(2) == $a;'),
             array('<?php return array($a) == $a;'),
-            array('<?php return $this->getStuff() === $myVarirable;'),
+            array('<?php return $this->getStuff() === $myVariable;'),
             array('<?php return 2 * $myVar % 3 === $a;'),
             array('<?php return ($a & self::MY_BITMASK) === $a;'),
             array('<?php return count($this->array[$var]) === $a;'),
@@ -48,8 +48,8 @@ class YodaConditionsFixerTest extends AbstractFixerTestBase
                 '<?php return $a == array($a);',
             ),
             array(
-                '<?php return $this->getStuff() === $myVarirable;',
-                '<?php return $myVarirable === $this->getStuff();',
+                '<?php return $this->getStuff() === $myVariable;',
+                '<?php return $myVariable === $this->getStuff();',
             ),
             array(
                 '<?php return 2 * $myVar % 3 === $a;',

--- a/Symfony/CS/Tests/Fixer/Symfony/YodaConditionsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/YodaConditionsFixerTest.php
@@ -110,7 +110,7 @@ class YodaConditionsFixerTest extends AbstractFixerTestBase
 if ($a == $b) {
     return null === $b ? (null === $a ? 0 : 0 === $a->b) : 0 === $b->a;
 } else {
-    if ($c === (null === $b)) {
+    if ((null === $b) === $c) {
         return false === $d;
     }
 }',


### PR DESCRIPTION
This PR

* [x] fixes the data provider for `YodaConditionsFixerTest::testFixer()` as some of the conditions provided actually *are* conditions that should be fixed (drops the number of failing tests from **7** to **1**)
* [x] also fixes irrelevant variable name spelling issues
* [x] fixes an invalid expectation (as far as I believe, a yoda condition would always have an expression on the left hand side that you should be unable to assign a value to, so here we go)